### PR TITLE
Document indexes

### DIFF
--- a/docs/sql/data_types/overview.md
+++ b/docs/sql/data_types/overview.md
@@ -14,7 +14,7 @@ The table below shows all the built-in general-purpose data types. The alternati
 | date |   | calendar date (year, month day) |
 | double | numeric | double precision floating-point number (8 bytes) |
 | integer | int, int4, signed | signed four-byte integer |
-| real | float4 | single precision floating-point number (4 bytes)|
+| real | float, float4 | single precision floating-point number (4 bytes)|
 | smallint | int2 | signed two-byte integer|
 | timestamp | datetime | time of day (no time zone) |
 | tinyint |   | signed one-byte integer|

--- a/docs/sql/indexes.md
+++ b/docs/sql/indexes.md
@@ -15,7 +15,7 @@ Indexes are currently [not persistent](https://github.com/cwida/duckdb/issues/69
 
 <div id="rrdiagram1"></div>
 
-`CREATE INDEX` constructs an index on the specified column(s) of the specified table. Compound indexes on multiple columns/expressions are supported. We currently only support unidimensional indexes.
+`CREATE INDEX` constructs an index on the specified column(s) of the specified table. Compound indexes on multiple columns/expressions are supported. Currently unidimensional indexes are supported, [multidimensional indexes are not supported](https://github.com/cwida/duckdb/issues/63).
 
 ### Parameters
 

--- a/docs/sql/indexes.md
+++ b/docs/sql/indexes.md
@@ -15,15 +15,7 @@ Indexes are currently [not persistent](https://github.com/cwida/duckdb/issues/69
 CREATE [ UNIQUE ] INDEX [ name ] ON table ({ column | ( expression )})
 ```
 
-`CREATE INDEX` constructs an index on the specified column(s) of the specified table. Compound indexes on multiple columns/expressions are supported. We currently only support unidimensional indexes of the following types:
-
-| Name | Aliases | Description |
-|:---|:---|:---|
-| bigint | int8 | signed eight-byte integer |
-| integer | int, int4, signed | signed four-byte integer |
-| smallint | int2 | signed two-byte integer |
-| tinyint |   | signed one-byte integer |
-| varchar | char, bpchar, text, string| variable-length character string |
+`CREATE INDEX` constructs an index on the specified column(s) of the specified table. Compound indexes on multiple columns/expressions are supported. We currently only support unidimensional indexes.
 
 ### Parameters
 

--- a/docs/sql/indexes.md
+++ b/docs/sql/indexes.md
@@ -41,8 +41,10 @@ CREATE [ UNIQUE ] INDEX [ name ] ON table ({ column | ( expression )})
 ```sql
 -- Create an unique index 'films_id_idx' on the column id of table films.
 CREATE UNIQUE INDEX films_id_idx ON films (id);
--- Creates index 's_idx' that allows for duplicate values on column revenue of table films.
+-- Create index 's_idx' that allows for duplicate values on column revenue of table films.
 CREATE INDEX revenue_idx ON films (revenue);
+-- Create compound index 'gy_idx' on genre and year columns.
+CREATE INDEX gy_idx ON films (genre, year);
 -- Create index 'i_index' on the expression of the sum of columns j and k from table integers.
 CREATE INDEX i_index ON integers ((j+k))
 ```

--- a/docs/sql/indexes.md
+++ b/docs/sql/indexes.md
@@ -2,6 +2,7 @@
 layout: docu
 title: Indexes
 selected: Documentation/Indexes
+railroad: statements/indexes.js
 ---
 DuckDB currently uses two index types:
 
@@ -11,9 +12,8 @@ DuckDB currently uses two index types:
 Indexes are currently [not persistent](https://github.com/cwida/duckdb/issues/693). Min-max indexes, unique and primary key indexes are rebuilt upon startup while user-defined adaptive radix tree indexes are discared.
 
 # Create Index
-```sql
-CREATE [ UNIQUE ] INDEX [ name ] ON table ({ column | ( expression )})
-```
+
+<div id="rrdiagram1"></div>
 
 `CREATE INDEX` constructs an index on the specified column(s) of the specified table. Compound indexes on multiple columns/expressions are supported. We currently only support unidimensional indexes.
 
@@ -42,11 +42,10 @@ CREATE INDEX i_index ON integers ((j+k))
 ```
 
 # Drop Index
-```sql
-DROP INDEX [ IF EXISTS ] name
-```
 
-DROP INDEX drops an existing index from the database system.
+<div id="rrdiagram2"></div>
+
+`DROP INDEX` drops an existing index from the database system.
 
 
 ### Parameters

--- a/docs/sql/indexes.md
+++ b/docs/sql/indexes.md
@@ -6,10 +6,8 @@ railroad: statements/indexes.js
 ---
 DuckDB currently uses two index types:
 
-* A [min-max index](https://en.wikipedia.org/wiki/Block_Range_Index) is automatically created for columns of all [general-purpose data types](/docs/sql/data_types/overview).
-* An [Adaptive Radix Tree](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.674.248&rep=rep1&type=pdf) is mainly used to ensure primary key constraints and to speed up point and very highly selective (i.e., < 0.1%) queries. Such an index can be defined using `CREATE INDEX` and it is automatically created for columns with a `UNIQUE` or `PRIMARY KEY` constraint.
-
-Indexes are currently [not persistent](https://github.com/cwida/duckdb/issues/693). Min-max indexes, unique and primary key indexes are rebuilt upon startup while user-defined adaptive radix tree indexes are discared.
+* A [min-max index](https://en.wikipedia.org/wiki/Block_Range_Index) is automatically created for columns of all [general-purpose data types](/docs/sql/data_types/overview). These indexes are persisted.
+* An [Adaptive Radix Tree](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.674.248&rep=rep1&type=pdf) is mainly used to ensure primary key constraints and to speed up point and very highly selective (i.e., < 0.1%) queries. Such an index is automatically created for columns with a `UNIQUE` or `PRIMARY KEY` constraint and can be defined using `CREATE INDEX`. Currently, Adaptive Radix Tree indexes are [not persistent](https://github.com/cwida/duckdb/issues/693). Unique and primary key indexes are rebuilt upon startup, while user-defined indexes are discarded.
 
 # Create Index
 

--- a/docs/sql/indexes.md
+++ b/docs/sql/indexes.md
@@ -4,12 +4,21 @@ title: Indexes
 selected: Documentation/Indexes
 railroad: statements/indexes.js
 ---
+## Index types
+
 DuckDB currently uses two index types:
 
-* A [min-max index](https://en.wikipedia.org/wiki/Block_Range_Index) is automatically created for columns of all [general-purpose data types](/docs/sql/data_types/overview). These indexes are persisted.
-* An [Adaptive Radix Tree](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.674.248&rep=rep1&type=pdf) is mainly used to ensure primary key constraints and to speed up point and very highly selective (i.e., < 0.1%) queries. Such an index is automatically created for columns with a `UNIQUE` or `PRIMARY KEY` constraint and can be defined using `CREATE INDEX`. Currently, Adaptive Radix Tree indexes are [not persistent](https://github.com/cwida/duckdb/issues/693). Unique and primary key indexes are rebuilt upon startup, while user-defined indexes are discarded.
+* A [min-max index](https://en.wikipedia.org/wiki/Block_Range_Index) is automatically created for columns of all [general-purpose data types](/docs/sql/data_types/overview).
+* An [Adaptive Radix Tree (ART)](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.674.248&rep=rep1&type=pdf) is mainly used to ensure primary key constraints and to speed up point and very highly selective (i.e., < 0.1%) queries. Such an index is automatically created for columns with a `UNIQUE` or `PRIMARY KEY` constraint and can be defined using `CREATE INDEX`.
 
-# Create Index
+Joins on columns with an ART index can make use of the [index join algorithm](https://en.wikipedia.org/wiki/Nested_loop_join#Index_join_variation). Forcing index joins is possible using [pragmas](/docs/sql/pragmas.md).
+
+## Persistence
+
+* Min-max indexes are persisted.
+* Currently, ART indexes are [not persisted](https://github.com/cwida/duckdb/issues/693). Unique and primary key indexes are rebuilt upon startup, while user-defined indexes are discarded.
+
+## Create Index
 
 <div id="rrdiagram1"></div>
 
@@ -39,7 +48,7 @@ CREATE INDEX gy_idx ON films (genre, year);
 CREATE INDEX i_index ON integers ((j+k))
 ```
 
-# Drop Index
+## Drop Index
 
 <div id="rrdiagram2"></div>
 

--- a/docs/sql/indexes.md
+++ b/docs/sql/indexes.md
@@ -3,20 +3,27 @@ layout: docu
 title: Indexes
 selected: Documentation/Indexes
 ---
-An Adaptive Radix Tree is used as the index data structure of choice for DuckDB. Its mainly used to ensure primary key constraints and to speed up point and very highly selective (i.e., < 0.1%) queries. Note that an index is automatically created for columns with a UNIQUE or PRIMARY KEY constrain.
+DuckDB currently uses two index types:
+
+* A [min-max index](https://en.wikipedia.org/wiki/Block_Range_Index) is automatically created for columns of all [general-purpose data types](/docs/sql/data_types/overview).
+* An [Adaptive Radix Tree](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.674.248&rep=rep1&type=pdf) is mainly used to ensure primary key constraints and to speed up point and very highly selective (i.e., < 0.1%) queries. Such an index can be defined using `CREATE INDEX` and it is automatically created for columns with a `UNIQUE` or `PRIMARY KEY` constraint.
+
+Indexes are currently [not persistent](https://github.com/cwida/duckdb/issues/693). Min-max indexes, unique and primary key indexes are rebuilt upon startup while user-defined adaptive radix tree indexes are discared.
 
 # Create Index
 ```sql
 CREATE [ UNIQUE ] INDEX [ name ] ON table ({ column | ( expression )})
 ```
-CREATE INDEX constructs an index on the specified column(s) of the specified table. We currently only support unidimensional indexes of the following types:
+
+`CREATE INDEX` constructs an index on the specified column(s) of the specified table. Compound indexes on multiple columns/expressions are supported. We currently only support unidimensional indexes of the following types:
 
 | Name | Aliases | Description |
 |:---|:---|:---|
 | bigint | int8 | signed eight-byte integer |
 | integer | int, int4, signed | signed four-byte integer |
-| smallint | int2 | signed two-byte integer|
-| tinyint |   | signed one-byte integer|
+| smallint | int2 | signed two-byte integer |
+| tinyint |   | signed one-byte integer |
+| varchar | char, bpchar, text, string| variable-length character string |
 
 ### Parameters
 

--- a/docs/sql/pragmas.md
+++ b/docs/sql/pragmas.md
@@ -120,6 +120,8 @@ PRAGMA disable_verification;
 PRAGMA force_parallelism;
 -- Disable force parallel query processing (for development)
 PRAGMA disable_force_parallelism;
+-- Force index joins where applicable
+PRAGMA force_index_join;
 ```
 
 These are PRAGMAs mostly used for development and internal testing.

--- a/js/statements/indexes.js
+++ b/js/statements/indexes.js
@@ -1,0 +1,53 @@
+
+
+function GenerateCreateIndex(options = {}) {
+	return Diagram([
+		Stack([
+			Sequence([
+				Keyword("CREATE"),
+				Optional(Keyword("UNIQUE"), "skip"),
+				Keyword("INDEX"),
+				Expression("name"),
+				Keyword("ON"),
+				Expression("table"),
+			]),
+			Sequence([
+				Keyword("("),
+				OneOrMore(
+					Choice(0, [
+						Expression("column"),
+						Sequence([Keyword("("),  Expression("expression"), Keyword(")")])
+					]),
+				Keyword(",")),
+				Keyword(")")
+			]),
+		])
+	])
+}
+
+function GenerateDropIndex(options = {}) {
+	return Diagram([
+		Sequence([
+			Keyword("DROP"),
+			Keyword("INDEX"),
+			Optional(Sequence([Keyword("IF"), Keyword("EXISTS")]), "skip"),
+			Expression("name")
+		]),
+	])
+}
+
+function Initialize(options = {}) {
+	document.getElementById("rrdiagram1").classList.add("limit-width");
+	document.getElementById("rrdiagram1").innerHTML = GenerateCreateIndex(options).toString();
+	document.getElementById("rrdiagram2").classList.add("limit-width");
+	document.getElementById("rrdiagram2").innerHTML = GenerateDropIndex(options).toString();
+}
+
+function Refresh(node_name, set_node) {
+	options[node_name] = set_node;
+	Initialize(options);
+}
+
+options = {}
+Initialize()
+


### PR DESCRIPTION
This PR aims to improve the documentation of indexes including [their current lack of persistence](https://github.com/cwida/duckdb/issues/1110).

A couple of questions:

1. The current grammar `CREATE [ UNIQUE ] INDEX [ name ] ON table ({ column | ( expression )})` is not 100% accurate as it does not allow for compound indexes.

2. The current [Indexes page](https://duckdb.org/docs/sql/indexes) in the documentation contains an incomplete table with the supported data types. I'm not sure whether it's worth putting this table here, particularly because all general-purpose types seem to be supported by `create index`:

```sql
create table t(
    my_bigint bigint,
    my_boolean boolean,
    my_blob blob,
    my_date date,
    my_double double,
    my_integer integer,
    my_real real,
    my_smallint smallint,
    my_timestamp timestamp,
    my_tinyint tinyint,
    my_varchar varchar);

create index idx_my_bigint on t(my_bigint);
create index idx_my_boolean on t(my_boolean);
create index idx_my_blob on t(my_blob);
create index idx_my_date on t(my_date);
create index idx_my_double on t(my_double);
create index idx_my_integer on t(my_integer);
create index idx_my_real on t(my_real);
create index idx_my_smallint on t(my_smallint);
create index idx_my_timestamp on t(my_timestamp);
create index idx_my_tinyint on t(my_tinyint);
create index idx_my_varchar on t(my_varchar);
```