### PR TITLE
Drop zero margin from unordered lists

### DIFF
--- a/css/docu.scss
+++ b/css/docu.scss
@@ -82,7 +82,6 @@ ul {
     list-style-type: '\2022 \00a0\00a0';
     padding: 0;
     padding-left: 0px;
-    margin: 0;
     ul{
 	    padding-left: 20px;
     }


### PR DESCRIPTION
Unordered lists didn't have enough space below them due to `margin: 0`.

## Before
![screen_2020-11-15_12-36-05](https://user-images.githubusercontent.com/1402801/99183855-535da100-273f-11eb-8b88-95616a8619f0.png)

## After
![screen_2020-11-15_12-36-25](https://user-images.githubusercontent.com/1402801/99183856-53f63780-273f-11eb-9516-126632e6c2b5.png)
