### PR TITLE
Add numeric type aliases

### DIFF
--- a/docs/sql/data_types/numeric.md
+++ b/docs/sql/data_types/numeric.md
@@ -5,14 +5,14 @@ selected: Documentation/Data Types/Numeric
 expanded: Data Types
 ---
 ## Integer Types
-The types `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT` AND `HUGEINT` store whole numbers, that is, numbers without fractional components, of various ranges. Attempts to store values outside of the allowed range will result in an error.
+The types `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT` and `HUGEINT` store whole numbers, that is, numbers without fractional components, of various ranges. Attempts to store values outside of the allowed range will result in an error.
 
 | Name | Aliases | Min | Max |
 |:---|:---|---:|---:|
-| `TINYINT` |   | -127 | 127 |
-| `SMALLINT` | `INT2` | -32767 | 32767 |
-| `INTEGER` | `INT`, `INT4`, `SIGNED` | -2147483647 | 2147483647 |
-| `BIGINT` | `INT8` | -9223372036854775808 | 9223372036854775808 |
+| `TINYINT` | `INT1` | -127 | 127 |
+| `SMALLINT` | `INT2`, `SHORT` | -32767 | 32767 |
+| `INTEGER` | `INT4`, `INT`, `SIGNED` | -2147483647 | 2147483647 |
+| `BIGINT` | `INT8`, `LONG` | -9223372036854775808 | 9223372036854775808 |
 | `HUGEINT` | | -170141183460469231731687303715884105727 | 170141183460469231731687303715884105727 |
 
 The type integer is the common choice, as it offers the best balance between range, storage size, and performance. The `SMALLINT` type is generally only used if disk space is at a premium. The `BIGINT` and `HUGEINT` types are designed to be used when the range of the integer type is insufficient.
@@ -37,7 +37,7 @@ The data types `REAL` and `DOUBLE` precision are inexact, variable-precision num
 | Name | Aliases | Description |
 |:---|:---|:---|
 | `REAL` | `FLOAT4` | single precision floating-point number (4 bytes)|
-| `DOUBLE` | | double precision floating-point number (8 bytes) |
+| `DOUBLE` | `FLOAT8` | double precision floating-point number (8 bytes) |
 
 Inexact means that some values cannot be converted exactly to the internal format and are stored as approximations, so that storing and retrieving a value might show slight discrepancies. Managing these errors and how they propagate through calculations is the subject of an entire branch of mathematics and computer science and will not be discussed here, except for the following points:
 

--- a/docs/sql/data_types/overview.md
+++ b/docs/sql/data_types/overview.md
@@ -8,16 +8,17 @@ The table below shows all the built-in general-purpose data types. The alternati
 
 | Name | Aliases | Description |
 |:---|:---|:---|
-| `BIGINT` | `INT8` | signed eight-byte integer |
-| `BOOLEAN` | `BOOL` | logical boolean (true/false) |
-| `BLOB` | `BYTEA` | variable-length binary data |
+| `BIGINT` | `INT8`, `LONG` | signed eight-byte integer |
+| `BOOLEAN` | `BOOL`, `LOGICAL` | logical boolean (true/false) |
+| `BLOB` | `BYTEA`, `BINARY,` `VARBINARY` | variable-length binary data |
 | `DATE` |   | calendar date (year, month day) |
-| `DOUBLE` | `NUMERIC` | double precision floating-point number (8 bytes) |
-| `INTEGER` | `INT`, `INT4`, `SIGNED` | signed four-byte integer |
-| `REAL` | `FLOAT`, `FLOAT4` | single precision floating-point number (4 bytes)|
-| `SMALLINT` | `INT2` | signed two-byte integer|
+| `DOUBLE` | `FLOAT8`, `NUMERIC`, `DECIMAL` | double precision floating-point number (8 bytes) |
+| `HUGEINT` | | signed sixteen-byte integer|
+| `INTEGER` | `INT4`, `INT`, `SIGNED` | signed four-byte integer |
+| `REAL` | `FLOAT4`, `FLOAT` | single precision floating-point number (4 bytes)|
+| `SMALLINT` | `INT2`, `SHORT` | signed two-byte integer|
 | `TIMESTAMP` | `DATETIME` | time of day (no time zone) |
-| `TINYINT` |   | signed one-byte integer|
+| `TINYINT` | `INT1` | signed one-byte integer|
 | `VARCHAR` | `CHAR`, `BPCHAR`, `TEXT`, `STRING` | variable-length character string |
 
 ### More


### PR DESCRIPTION
While working on https://github.com/cwida/duckdb/pull/1256, I encountered a few inconsistencies in the docs. This PR amends them.

Even the tables in the PR omit a few typenames such as `INT16` (=`INT2`), `INT32` (=`INT4`), and `INT64` (=`INT8`). Should we include them or keep them omitted (as they can be confusing for newcomers).