### PR TITLE
Formatting and setseed example

### DIFF
--- a/docs/sql/data_types/date.md
+++ b/docs/sql/data_types/date.md
@@ -8,7 +8,7 @@ expanded: Data Types
 |:---|:---|:---|
 | `DATE` |   | calendar date (year, month day) |
 
-A date specifies a combination of year, month and day. DuckDB follows the SQL standard's lead by counting dates exclusively in the Gregorian calendar, even for years before that calendar was in use. Dates can be created using the `DATE` keyword, where the data must be formatted according to the ISO 8601 format (YYYY-MM-DD).
+A date specifies a combination of year, month and day. DuckDB follows the SQL standard's lead by counting dates exclusively in the Gregorian calendar, even for years before that calendar was in use. Dates can be created using the `DATE` keyword, where the data must be formatted according to the ISO 8601 format (`YYYY-MM-DD`).
 
 ```sql
 -- 20 September, 1992

--- a/docs/sql/data_types/numeric.md
+++ b/docs/sql/data_types/numeric.md
@@ -23,25 +23,25 @@ The types `UTINYINT`, `USMALLINT`, `UINTEGER`, `UBIGINT` store whole unsigned nu
 The type integer is the common choice, as it offers the best balance between range, storage size, and performance. The `SMALLINT` type is generally only used if disk space is at a premium. The `BIGINT` and `HUGEINT` types are designed to be used when the range of the integer type is insufficient.
 
 ## Fixed-Point Decimals
-The data type `decimal` represents an exact fixed-point decimal value. When creating a value of type `decimal`, the `width` and `scale` can be specified to define which size of decimal values can be held in the field. The `width` field determines how many digits can be held, and the `scale` determines the amount of digits after the decimal point. For example, the type `DECIMAL(3,2)` can fit the value `1.23`, but cannot fit the value `12.3` or the value `1.234`. The default `width` and `scale` is `DECIMAL(18,3)`, if none are specified.
+The data type `DECIMAL` represents an exact fixed-point decimal value. When creating a value of type `DECIMAL`, the `WIDTH` and `SCALE` can be specified to define which size of decimal values can be held in the field. The `WIDTH` field determines how many digits can be held, and the `scale` determines the amount of digits after the decimal point. For example, the type `DECIMAL(3,2)` can fit the value `1.23`, but cannot fit the value `12.3` or the value `1.234`. The default `WIDTH` and `SCALE` is `DECIMAL(18,3)`, if none are specified.
 
 Internally, decimals are represented as integers depending on their specified width.
 
 | Width | Internal | Size (Bytes) |
 |:---|:---|---:|
-| 1-4 | `int16` | 2 |
-| 5-9 | `int32` | 4 |
-| 10-18 | `int64` | 8 |
-| 19-38 | `int128` | 16 |
+| 1-4 | `INT16` | 2 |
+| 5-9 | `INT32` | 4 |
+| 10-18 | `INT64` | 8 |
+| 19-38 | `INT128` | 16 |
 
-Performance can be impacted by using too large decimals when not required. In particular decimal values with a width above 19 are very slow, as arithmetic involving the `int128` type is much more expensive than operations involving the `int32` or `int64` types. It is therefore recommended to stick with a width of `18` or below, unless there is a good reason for why this is insufficient.
+Performance can be impacted by using too large decimals when not required. In particular decimal values with a width above 19 are very slow, as arithmetic involving the `INT128` type is much more expensive than operations involving the `INT32` or `INT64` types. It is therefore recommended to stick with a width of `18` or below, unless there is a good reason for why this is insufficient.
 
 ## Floating-Point Types
 The data types `REAL` and `DOUBLE` precision are inexact, variable-precision numeric types. In practice, these types are usually implementations of IEEE Standard 754 for Binary Floating-Point Arithmetic (single and double precision, respectively), to the extent that the underlying processor, operating system, and compiler support it.
 
 | Name | Aliases | Description |
 |:---|:---|:---|
-| `REAL` | `FLOAT4` | single precision floating-point number (4 bytes)|
+| `REAL` | `FLOAT4` | single precision floating-point number (4 bytes) |
 | `DOUBLE` | `FLOAT8` | double precision floating-point number (8 bytes) |
 
 Inexact means that some values cannot be converted exactly to the internal format and are stored as approximations, so that storing and retrieving a value might show slight discrepancies. Managing these errors and how they propagate through calculations is the subject of an entire branch of mathematics and computer science and will not be discussed here, except for the following points:

--- a/docs/sql/data_types/numeric.md
+++ b/docs/sql/data_types/numeric.md
@@ -23,7 +23,7 @@ The types `UTINYINT`, `USMALLINT`, `UINTEGER`, `UBIGINT` store whole unsigned nu
 The type integer is the common choice, as it offers the best balance between range, storage size, and performance. The `SMALLINT` type is generally only used if disk space is at a premium. The `BIGINT` and `HUGEINT` types are designed to be used when the range of the integer type is insufficient.
 
 ## Fixed-Point Decimals
-The data type `DECIMAL` represents an exact fixed-point decimal value. When creating a value of type `DECIMAL`, the `WIDTH` and `SCALE` can be specified to define which size of decimal values can be held in the field. The `WIDTH` field determines how many digits can be held, and the `scale` determines the amount of digits after the decimal point. For example, the type `DECIMAL(3,2)` can fit the value `1.23`, but cannot fit the value `12.3` or the value `1.234`. The default `WIDTH` and `SCALE` is `DECIMAL(18,3)`, if none are specified.
+The data type `DECIMAL(WIDTH,SCALE)` represents an exact fixed-point decimal value. When creating a value of type `DECIMAL`, the `WIDTH` and `SCALE` can be specified to define which size of decimal values can be held in the field. The `WIDTH` field determines how many digits can be held, and the `scale` determines the amount of digits after the decimal point. For example, the type `DECIMAL(3,2)` can fit the value `1.23`, but cannot fit the value `12.3` or the value `1.234`. The default `WIDTH` and `SCALE` is `DECIMAL(18,3)`, if none are specified.
 
 Internally, decimals are represented as integers depending on their specified width.
 

--- a/docs/sql/data_types/timestamp.md
+++ b/docs/sql/data_types/timestamp.md
@@ -8,7 +8,7 @@ expanded: Data Types
 |:---|:---|:---|
 | `TIMESTAMP` | datetime | time of day (no time zone) |
 
-A timestamp specifies a combination of `DATE` (year, month, day) and a `TIME` (hour, minute, second, millisecond). Timestamps can be created using the `TIMESTAMP` keyword, where the data must be formatted according to the ISO 8601 format (YYYY-MM-DD hh:mm:ss).
+A timestamp specifies a combination of `DATE` (year, month, day) and a `TIME` (hour, minute, second, millisecond). Timestamps can be created using the `TIMESTAMP` keyword, where the data must be formatted according to the ISO 8601 format (`YYYY-MM-DD hh:mm:ss`).
 
 ```sql
 -- 11:30 AM at 20 September, 1992

--- a/docs/sql/functions/date.md
+++ b/docs/sql/functions/date.md
@@ -12,4 +12,4 @@ This section describes functions and operators for examining and manipulating da
 | `date_part(`*`part`*`, `*`date`*`)` | Get subfield (equivalent to *extract*) | `date_part('year', DATE '1992-09-20')` | 1992 |
 | `date_trunc(`*`part`*`, `*`date`*`)` | Truncate to specified precision | `date_trunc('month', DATE '1992-03-07')` | 1992-03-01 |
 | `extract(`*`part`* `from` *`date`*`)` | Get subfield from a date | `extract('year' FROM DATE '1992-09-20')` | 1992 |
-| `strftime(date, format)` | Converts date to string according to format (see [Date Format](/docs/sql/functions/dateformat)) | strftime(date '1992-01-01', '%a, %-d %B %Y') | Wed, 1 January 1992 |
+| `strftime(date, format)` | Converts date to string according to format (see [Date Format](/docs/sql/functions/dateformat)) | `strftime(date '1992-01-01', '%a, %-d %B %Y')` | Wed, 1 January 1992 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -46,7 +46,7 @@ The table below shows the available mathematical functions.
 | `radians(x)` | converts degrees to radians | `radians(90)` | 1.5707963267948966 |
 | `random()` | returns a random number between 0 and 1 | `random()` | ... |
 | `round(v numeric, s int)` | round to *s* decimal places | `round(42.4332, 2)` | 42.43 |
-| `setseed(x)` | sets the seed to be used for the random function | `setseed()` | |
+| `setseed(x)` | sets the seed to be used for the random function | `setseed(0.42)` | |
 | `sin(x)` | computes the sin of x | `sin(90)` | 0.8939966636005579 |
 | `sign(x)` | returns the sign of x as -1, 0 or 1 | `sign(-349)` | -1 |
 | `sqrt(x)` | returns the square root of the number | `sqrt(9)` | 3 |

--- a/docs/sql/functions/timestamp.md
+++ b/docs/sql/functions/timestamp.md
@@ -17,5 +17,5 @@ This section describes functions and operators for examining and manipulating ti
 | `epoch_ms(ms)` | Converts ms since epoch to a timestamp | `epoch(0)` | 1970-01-01 00:00:00 |
 | `extract(`*`field`* `from` *`timestamp`*`)` | Get subfield from a timestamp | `extract('hour' FROM TIMESTAMP '1992-09-20 20:38:48')` | 20 |
 | `now()` | Current date and time (start of current transaction) | | |
-| `strftime(timestamp, format)` | Converts timestamp to string according to format (see [Date Format](/docs/sql/functions/dateformat)) | strftime(timestamp '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p') | Wed, 1 January 1992 - 08:38:40 PM |
-| `strptime(text, format)` | Converts string to timestamp according to format (see [Date Format](/docs/sql/functions/dateformat)) | strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p') | 1992-01-01 20:38:40 |
+| `strftime(timestamp, format)` | Converts timestamp to string according to format (see [Date Format](/docs/sql/functions/dateformat)) | `strftime(timestamp '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p')` | Wed, 1 January 1992 - 08:38:40 PM |
+| `strptime(text, format)` | Converts string to timestamp according to format (see [Date Format](/docs/sql/functions/dateformat)) | `strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p')` | 1992-01-01 20:38:40 |

--- a/docs/sql/introduction.md
+++ b/docs/sql/introduction.md
@@ -70,7 +70,7 @@ The insert statement is used to populate a table with rows:
 INSERT INTO weather VALUES ('San Francisco', 46, 50, 0.25, '1994-11-27');
 ```
 
-Constants that are not numeric values (e.g. text and dates) must be surrounded by single quotes (`''`), as in the example. Input dates for the date type must be formatted as 'YYYY-MM-DD'.
+Constants that are not numeric values (e.g. text and dates) must be surrounded by single quotes (`''`), as in the example. Input dates for the date type must be formatted as `'YYYY-MM-DD'`.
 
 We can insert into the *cities* table in the same manner.
 

--- a/docs/sql/pragmas.md
+++ b/docs/sql/pragmas.md
@@ -83,20 +83,31 @@ Enable the gathering and printing of profiling information after the execution o
 Below is an example output of the profiling information for the simple query ```SELECT 42```:
 
 ```
-<<Query Profiling Information>>
+┌─────────────────────────────────────┐
+│┌───────────────────────────────────┐│
+││    Query Profiling Information    ││
+│└───────────────────────────────────┘│
+└─────────────────────────────────────┘
 SELECT 42;
-<<Operator Tree>>
---------------------
-|    PROJECTION    |
-|        42        |
-|      (0.00s)     |
-|         1        |
---------------------
---------------------
-|    DUMMY_SCAN    |
-|      (0.00s)     |
-|         1        |
---------------------
+┌─────────────────────────────────────┐
+│┌───────────────────────────────────┐│
+││        Total Time: 0.0001s        ││
+│└───────────────────────────────────┘│
+└─────────────────────────────────────┘
+┌───────────────────────────┐
+│         PROJECTION        │
+│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+│             42            │
+│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+│             1             │
+│          (0.00s)          │
+└─────────────┬─────────────┘                             
+┌─────────────┴─────────────┐
+│         DUMMY_SCAN        │
+│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+│             1             │
+│          (0.00s)          │
+└───────────────────────────┘
 ```
 
 The printing of profiling information can be disabled again using *disable_profiling*.


### PR DESCRIPTION
I fixed a bunch of formatting/typesetting errors and the example call of `setseed`.

I also updated the profiling example to use the new prettyprinting syntax:

![image](https://user-images.githubusercontent.com/1402801/111233089-a14ebc80-85ec-11eb-9b35-1169d3c58643.png)
